### PR TITLE
Add blackbox exporter

### DIFF
--- a/kubernetes/namespaces/automation/n8n/service.yml
+++ b/kubernetes/namespaces/automation/n8n/service.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: n8n
+  annotations:
+    prometheus.io/probe: 'true'
 spec:
   selector:
     app: n8n

--- a/kubernetes/namespaces/default/blink/service.yml
+++ b/kubernetes/namespaces/default/blink/service.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: blink
+  annotations:
+    prometheus.io/probe: 'true'
 spec:
   selector:
     app: blink

--- a/kubernetes/namespaces/default/minio/service.yml
+++ b/kubernetes/namespaces/default/minio/service.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: minio
+  annotations:
+    prometheus.io/probe: 'true'
 spec:
   selector:
     app: minio

--- a/kubernetes/namespaces/default/outline/service.yml
+++ b/kubernetes/namespaces/default/outline/service.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: outline
+  annotations:
+    prometheus.io/probe: 'true'
 spec:
   selector:
     app: outline

--- a/kubernetes/namespaces/default/pastebin/service.yml
+++ b/kubernetes/namespaces/default/pastebin/service.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pastebin
+  annotations:
+    prometheus.io/probe: 'true'
 spec:
   selector:
     app: pastebin

--- a/kubernetes/namespaces/monitoring/alertmanager/service.yml
+++ b/kubernetes/namespaces/monitoring/alertmanager/service.yml
@@ -20,6 +20,7 @@ metadata:
   name: alertmanager
   annotations:
     prometheus.io/scrape: 'true'
+    prometheus.io/probe: 'true'
 spec:
   selector:
     app: alertmanager

--- a/kubernetes/namespaces/monitoring/blackbox-exporter/deployment.yml
+++ b/kubernetes/namespaces/monitoring/blackbox-exporter/deployment.yml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+spec:
+  selector:
+    matchLabels:
+      app: blackbox-exporter
+  template:
+    metadata:
+      labels:
+        app: blackbox-exporter
+    spec:
+      containers:
+        - image: prom/blackbox-exporter:v0.25.0
+          imagePullPolicy: IfNotPresent
+          name: blackbox-exporter
+          ports:
+            - containerPort: 9115
+              name: http

--- a/kubernetes/namespaces/monitoring/blackbox-exporter/service.yml
+++ b/kubernetes/namespaces/monitoring/blackbox-exporter/service.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter
+spec:
+  selector:
+    app: blackbox-exporter
+  ports:
+  - name: blackbox-exporter
+    port: 80
+    targetPort: http

--- a/kubernetes/namespaces/monitoring/grafana/service.yml
+++ b/kubernetes/namespaces/monitoring/grafana/service.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: grafana
+  annotations:
+    prometheus.io/probe: 'true'
 spec:
   selector:
     app: grafana

--- a/kubernetes/namespaces/monitoring/prometheus/prometheus.yml
+++ b/kubernetes/namespaces/monitoring/prometheus/prometheus.yml
@@ -79,3 +79,29 @@ scrape_configs:
       - action: replace
         source_labels: [__meta_kubernetes_node_name]
         target_label: node
+
+  # Blackbox prober for kubernetes services.
+  # The service should have a `prometheus.io/probe: 'true'` annotation
+  - job_name: "blackbox-kubernetes-services"
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    kubernetes_sd_configs:
+    - role: service
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_probe]
+        action: keep
+        regex: true
+      - source_labels: [__address__]
+        target_label: __param_target
+      - target_label: __address__
+        replacement:  blackbox-exporter.default.svc.cluster.local
+      - source_labels: [__param_target]
+        target_label: instance
+      - action: labelmap
+        regex: __meta_kubernetes_service_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_service_name]
+        target_label: kubernetes_service_name
+

--- a/kubernetes/namespaces/monitoring/uptime-kuma/service.yml
+++ b/kubernetes/namespaces/monitoring/uptime-kuma/service.yml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: uptime-kuma
+  annotations:
+    prometheus.io/probe: 'true'
 spec:
   selector:
     app: uptime-kuma


### PR DESCRIPTION
# Description

I’m currently using UptimeKuma to track the uptime of my services. This PR adds the Blackbox exporter as another option, so I can monitor the services with Prometheus and Grafana and set up alert rules later.

![image](https://github.com/user-attachments/assets/ef99c105-ff99-43a9-add6-952f89daef1c)
